### PR TITLE
Update CICD-base.yaml

### DIFF
--- a/.github/workflows/CICD-base.yaml
+++ b/.github/workflows/CICD-base.yaml
@@ -22,4 +22,4 @@ jobs:
 
       # Run CICD-base
       - name: CICD-base
-        uses: docker://blcdsdockerregistry/cicd-base:latest
+        uses: docker://ghcr.io/uclahs-cds/cicd-base:latest

--- a/generate_checksum/checksum.py
+++ b/generate_checksum/checksum.py
@@ -56,7 +56,7 @@ def _generate_sha512(path:Path):
 
 def _write_checksum_file(path:Path, hash_type:str, computed_hash:str):
     ''' Write checksum to file '''
-    with open(str(path) + '.' + hash_type, 'w') as checksum_file:
+    with open(str(path) + '.' + hash_type, 'w', encoding="utf-8") as checksum_file:
         checksum_file.write(computed_hash + '  ' + str(path) + '\n')
 
     print(f'{hash_type} checksum generated for {str(path)}')


### PR DESCRIPTION
I found another one!

I did have to make one change to add the `encoding='utf-8'` argument to `open()` to make pylint happy.

https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/unspecified-encoding.html

For sanity I confirmed that the [default](https://docs.python.org/3.10/library/functions.html#open) [encoding](https://docs.python.org/3.10/library/locale.html#locale.getpreferredencoding) used in the docker image is indeed UTF-8:
```console
$ docker run -it --rm --entrypoint /bin/bash ghcr.io/uclahs-cds/pipeval:4.0.0-rc.2
bldocker@e90e52ddfca8:/tool$ python3 -c "import locale; print(locale.getpreferredencoding())"
UTF-8
```