### PR TITLE
Parallelize validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,23 @@ The tool can be installed as a standalone command line tool. The following depen
 |Python|3.10|
 |VCFtools|0.1.16|
 
-### Install directly from GitHub
+Additionally, the `libmagic` C library must also be installed on the system.
+
+With the dependencies (and the proper versions) installed, install `pipeval` through one of the options below:
+
+### Install directly from GitHub through SSH
 ```Bash
 pip install git+ssh://git@github.com/uclahs-cds/package-PipeVal.git
 ```
 
+### Install directly from GitHub through HTTPS
+```Bash
+pip install git+https://git@github.com/uclahs-cds/package-PipeVal.git
+```
+
 ### Install from cloned repository
 ```Bash
+<clone the PipeVal GitHub repository>
 cd </path/to/cloned/repository>
 pip install .
 ```
@@ -55,6 +65,7 @@ options:
   -v, --version         show program's version number and exit
   -r CRAM_REFERENCE, --cram-reference CRAM_REFERENCE
                         Path to reference file for CRAM
+  -c CPUS, --cpus CPUS  Number of CPUs to parallelize over when validating multiple files
 ```
 
 The tool will attempt to automatically detect the file type based on extension and perform the approriate validations. The tool will also perform an existence check along with a checksum check if an MD5 or SHA512 checksum exists regardless of file type.

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ pytest
 ## Discussions
 
 - [Issue tracker](https://github.com/uclahs-cds/package-PipeVal/issues) to report errors and enhancement ideas.
-- Discussions can take place in [tool-NF-test Discussions](https://github.com/uclahs-cds/package-PipeVal/discussions)
-- [tool-NF-test pull requests](https://github.com/uclahs-cds/package-PipeVal/pulls) are also open for discussion
+- Discussions can take place in [package-PipeVal Discussions](https://github.com/uclahs-cds/package-PipeVal/discussions)
+- [package-PipeVal pull requests](https://github.com/uclahs-cds/package-PipeVal/pulls) are also open for discussion
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ options:
   -v, --version         show program's version number and exit
   -r CRAM_REFERENCE, --cram-reference CRAM_REFERENCE
                         Path to reference file for CRAM
-  -c CPUS, --cpus CPUS  Number of CPUs to parallelize over when validating multiple files
+  -p PROCESSES, --processes PROCESSES
+                        Number of processes to run in parallel when validating multiple files
 ```
 
 The tool will attempt to automatically detect the file type based on extension and perform the approriate validations. The tool will also perform an existence check along with a checksum check if an MD5 or SHA512 checksum exists regardless of file type.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ The tool can be installed as a standalone command line tool. The following depen
 
 Additionally, the `libmagic` C library must also be installed on the system.
 
+### Installing `libmagic`
+
+On Debian/Ubuntu, install through:
+```Bash
+sudo apt-get install libmagic-dev
+```
+
+On Mac, install through homebrew (https://brew.sh/):
+```Bash
+brew install libmagic
+```
+
+`libmagic` can also be installed through the `conda` package manager:
+```Bash
+conda install -c conda-forge libmagic
+```
+
 With the dependencies (and the proper versions) installed, install `pipeval` through one of the options below:
 
 ### Install directly from GitHub through SSH

--- a/test/unit/test_generate_checksum.py
+++ b/test/unit/test_generate_checksum.py
@@ -110,7 +110,7 @@ def test__write_checksum_file__writes_proper_checksum(mock_path, mock_write_open
 
     _write_checksum_file(mock_path, hash_type, computed_hash)
 
-    mock_write_open.assert_called_once_with(f'{file_path}.{hash_type}', 'w')
+    mock_write_open.assert_called_once_with(f'{file_path}.{hash_type}', 'w', encoding='utf-8')
 
     handle = mock_write_open()
     handle.write.assert_called_once_with(f'{computed_hash}  {file_path}\n')

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -229,7 +229,7 @@ def test__validate_vcf_file__passes_vcf_validation(mock_call):
     _validate_vcf_file('some/file')
 
 def test__run_validate__passes_validation_no_files():
-    test_args = ValidateArgs(path=[], cram_reference=None, cpus=1)
+    test_args = ValidateArgs(path=[], cram_reference=None, processes=1)
     run_validate(test_args)
 
 @pytest.mark.parametrize(
@@ -252,7 +252,7 @@ def test___validation_worker__fails_with_failing_checks(
     mock_detect_file_type_and_extension,
     test_exception):
     test_path = 'some/path'
-    test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
+    test_args = ValidateArgs(path=[test_path], cram_reference=None, processes=1)
     mock_path_resolve.return_value = test_path
     mock_validate_file.side_effect = test_exception
     mock_detect_file_type_and_extension.return_value = ('', '')
@@ -267,7 +267,7 @@ def test__run_validate__passes_on_all_valid_files(
     mock_path_resolve
     ):
     test_path = 'some/path'
-    test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
+    test_args = ValidateArgs(path=[test_path], cram_reference=None, processes=1)
 
     mock_path_resolve.return_value = None
     mock_pool.return_value.__enter__.return_value = Namespace(starmap=lambda y, z: [True])
@@ -280,7 +280,7 @@ def test__run_validate__fails_with_failing_file(
     mock_pool,
     mock_path_resolve):
     test_path = 'some/path'
-    test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
+    test_args = ValidateArgs(path=[test_path], cram_reference=None, processes=1)
     expected_code = 1
 
     mock_path_resolve.return_value = None
@@ -330,7 +330,7 @@ def test__run_validate__fails_on_unresolvable_symlink(mock_path_resolve):
 
     test_path = 'some/path'
 
-    test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
+    test_args = ValidateArgs(path=[test_path], cram_reference=None, processes=1)
 
     with pytest.raises(expected_error):
         run_validate(test_args)
@@ -351,6 +351,6 @@ def test___validation_worker__passes_proper_validation(
 
     test_path = 'some/path'
 
-    test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
+    test_args = ValidateArgs(path=[test_path], cram_reference=None, processes=1)
 
     _validation_worker(test_path, test_args)

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -1,11 +1,11 @@
 # pylint: disable=C0116
 # pylint: disable=C0114
 from pathlib import Path
+from argparse import Namespace
 from unittest.mock import Mock
 import warnings
 import mock
 import pytest
-from argparse import Namespace
 
 from validate.files import (
     _check_compressed,
@@ -250,7 +250,7 @@ def test__run_validate__passes_on_all_valid_files(
     test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
 
     mock_path_resolve.return_value = None
-    mock_pool.return_value = Namespace(starmap=lambda y, z: [True])
+    mock_pool.return_value.__enter__.return_value = Namespace(starmap=lambda y, z: [True])
 
     run_validate(test_args)
 
@@ -264,7 +264,7 @@ def test__run_validate__fails_with_failing_file(
     expected_code = 1
 
     mock_path_resolve.return_value = None
-    mock_pool.return_value = Namespace(starmap=lambda y, z: [False])
+    mock_pool.return_value.__enter__.return_value = Namespace(starmap=lambda y, z: [False])
 
     with pytest.raises(SystemExit) as pytest_exit:
         run_validate(test_args)

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import warnings
 import mock
 import pytest
+from argparse import Namespace
 
 from validate.files import (
     _check_compressed,
@@ -28,7 +29,8 @@ from validate.validate import (
     _detect_file_type_and_extension,
     _check_extension,
     run_validate,
-    _validate_file
+    _validate_file,
+    _validation_worker
 )
 from validate.validate_types import ValidateArgs
 
@@ -206,10 +208,8 @@ def test__validate_vcf_file__passes_vcf_validation(mock_call):
 
     _validate_vcf_file('some/file')
 
-@mock.patch('validate.validate._print_success')
-def test__run_validate__passes_validation_no_files(mock_print_success):
-    test_args = ValidateArgs(path=[], cram_reference=None)
-    mock_print_success.return_value = ''
+def test__run_validate__passes_validation_no_files():
+    test_args = ValidateArgs(path=[], cram_reference=None, cpus=1)
     run_validate(test_args)
 
 @pytest.mark.parametrize(
@@ -225,18 +225,46 @@ def test__run_validate__passes_validation_no_files(mock_print_success):
 @mock.patch('validate.validate._validate_file')
 @mock.patch('validate.validate._print_error')
 @mock.patch('validate.validate.Path.resolve')
-def test__run_validate__fails_with_failing_checks(
+def test___validation_worker__fails_with_failing_checks(
     mock_path_resolve,
     mock_print_error,
     mock_validate_file,
     mock_detect_file_type_and_extension,
     test_exception):
-    test_args = ValidateArgs(path=['some/path'], cram_reference=None)
-    mock_path_resolve.return_value = 'some/path'
+    test_path = 'some/path'
+    test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
+    mock_path_resolve.return_value = test_path
     mock_validate_file.side_effect = test_exception
     mock_detect_file_type_and_extension.return_value = ('', '')
     mock_print_error.return_value = ''
+
+    assert not _validation_worker(test_path, test_args)
+
+@mock.patch('validate.validate.Path.resolve', autospec=True)
+@mock.patch('validate.validate.multiprocessing.Pool')
+def test__run_validate__passes_on_all_valid_files(
+    mock_pool,
+    mock_path_resolve
+    ):
+    test_path = 'some/path'
+    test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
+
+    mock_path_resolve.return_value = None
+    mock_pool.return_value = Namespace(starmap=lambda y, z: [True])
+
+    run_validate(test_args)
+
+@mock.patch('validate.validate.Path.resolve', autospec=True)
+@mock.patch('validate.validate.multiprocessing.Pool')
+def test__run_validate__fails_with_failing_file(
+    mock_pool,
+    mock_path_resolve):
+    test_path = 'some/path'
+    test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
     expected_code = 1
+
+    mock_path_resolve.return_value = None
+    mock_pool.return_value = Namespace(starmap=lambda y, z: [False])
 
     with pytest.raises(SystemExit) as pytest_exit:
         run_validate(test_args)
@@ -280,7 +308,9 @@ def test__run_validate__fails_on_unresolvable_symlink(mock_path_resolve):
     expected_error = FileNotFoundError
     mock_path_resolve.side_effect = expected_error
 
-    test_args = ValidateArgs(path=['some/path'], cram_reference=None)
+    test_path = 'some/path'
+
+    test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
 
     with pytest.raises(expected_error):
         run_validate(test_args)
@@ -289,7 +319,7 @@ def test__run_validate__fails_on_unresolvable_symlink(mock_path_resolve):
 @mock.patch('validate.validate._detect_file_type_and_extension')
 @mock.patch('validate.validate._validate_file')
 @mock.patch('validate.validate._print_success')
-def test__run_validate__passes_proper_validation(
+def test___validation_worker__passes_proper_validation(
     mock_print_success,
     mock_validate_file,
     mock_detect_file_type_and_extension,
@@ -299,6 +329,8 @@ def test__run_validate__passes_proper_validation(
     mock_validate_file.return_value = None
     mock_path_resolve.return_value = None
 
-    test_args = ValidateArgs(path=['some/path'], cram_reference=None)
+    test_path = 'some/path'
 
-    run_validate(test_args)
+    test_args = ValidateArgs(path=[test_path], cram_reference=None, cpus=1)
+
+    _validation_worker(test_path, test_args)

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -1,7 +1,7 @@
 # pylint: disable=C0116
 # pylint: disable=C0114
 from pathlib import Path
-from argparse import Namespace
+from argparse import Namespace, ArgumentTypeError
 from unittest.mock import Mock
 import warnings
 import mock
@@ -32,7 +32,27 @@ from validate.validate import (
     _validate_file,
     _validation_worker
 )
+from validate.__main__ import positive_integer
 from validate.validate_types import ValidateArgs
+
+def test__positive_integer__returns_correct_integer():
+    expected_number = 2
+    number_str = '2'
+    assert expected_number == positive_integer(number_str)
+
+@pytest.mark.parametrize(
+    'number_str',
+    [
+        ('-2'),
+        ('0'),
+        ('1.2'),
+        ('number'),
+        ('')
+    ]
+)
+def test__positive_integer__fails_non_positive_integers(number_str):
+    with pytest.raises(ArgumentTypeError):
+        positive_integer(number_str)
 
 @pytest.mark.parametrize(
     'expected_extension, expected_file_type',

--- a/validate/__init__.py
+++ b/validate/__init__.py
@@ -1,3 +1,3 @@
 '''Inits validate module'''
 
-__version__ = '4.0.0-rc.2'
+__version__ = '4.0.0'

--- a/validate/__main__.py
+++ b/validate/__main__.py
@@ -10,8 +10,8 @@ def positive_integer(arg):
     except ValueError as value_exception:
         raise argparse.ArgumentTypeError("Must be an integer.") from value_exception
 
-    if i < 0:
-        raise argparse.ArgumentTypeError("Must be an integer greater than or equal to 0.")
+    if i < 1:
+        raise argparse.ArgumentTypeError("Must be an integer greater than 0.")
 
     return i
 

--- a/validate/__main__.py
+++ b/validate/__main__.py
@@ -3,6 +3,18 @@ import argparse
 from validate import __version__
 from validate.validate import run_validate
 
+def positive_integer(arg):
+    """ Type and value check for positive integers """
+    try:
+        i = int(arg)
+    except ValueError as value_exception:
+        raise argparse.ArgumentTypeError("Must be an integer.") from value_exception
+
+    if i < 0:
+        raise argparse.ArgumentTypeError("Must be an integer greater than or equal to 0.")
+
+    return i
+
 def _parse_args():
     """ Parse arguments """
     parser = argparse.ArgumentParser()
@@ -10,6 +22,8 @@ def _parse_args():
     parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {__version__}')
     parser.add_argument('-r', '--cram-reference', default=None, \
         help='Path to reference file for CRAM')
+    parser.add_argument('-c', '--cpus', type=positive_integer, default=1, \
+        help='Number of CPUs to parallelize over when validating multiple files')
 
     parser.set_defaults(func=run_validate)
 

--- a/validate/__main__.py
+++ b/validate/__main__.py
@@ -22,8 +22,8 @@ def _parse_args():
     parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {__version__}')
     parser.add_argument('-r', '--cram-reference', default=None, \
         help='Path to reference file for CRAM')
-    parser.add_argument('-c', '--cpus', type=positive_integer, default=1, \
-        help='Number of CPUs to parallelize over when validating multiple files')
+    parser.add_argument('-p', '--processes', type=positive_integer, default=1, \
+        help='Number of processes to run in parallel when validating multiple files')
 
     parser.set_defaults(func=run_validate)
 

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -1,6 +1,7 @@
 ''' File validation functions '''
 from pathlib import Path
 import sys
+import os
 from typing import Dict, Union
 import multiprocessing
 from itertools import repeat
@@ -59,11 +60,11 @@ def _validate_file(
 
 def _print_error(path:Path, err:BaseException):
     ''' Prints error message '''
-    print(f'Error: {str(path)} {str(err)}')
+    print(f'PID:{os.getpid()} - Error: {str(path)} {str(err)}')
 
 def _print_success(path:Path, file_type:str):
     ''' Prints success message '''
-    print(f'Input: {path} is valid {file_type}')
+    print(f'PID:{os.getpid()} - Input: {path} is valid {file_type}')
 
 def _detect_file_type_and_extension(path:Path):
     ''' File type and extension detection '''

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -110,7 +110,7 @@ def run_validate(args:Union[ValidateArgs,Dict[str, Union[str,list]]]):
         `cram_reference` is a required argument with either a string value or None
     '''
 
-    num_parallel = min(args.cpus, multiprocessing.cpu_count())
+    num_parallel = min(args.processes, multiprocessing.cpu_count())
 
     with multiprocessing.Pool(num_parallel) as parallel_pool:
         validation_results = parallel_pool.starmap(_validation_worker, \

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -4,7 +4,6 @@ import sys
 from typing import Dict, Union
 import multiprocessing
 from itertools import repeat
-from time import sleep
 
 from validate.validators.bam import _check_bam
 from validate.validators.sam import _check_sam

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -111,9 +111,9 @@ def run_validate(args:Union[ValidateArgs,Dict[str, Union[str,list]]]):
 
     num_parallel = min(args.cpus, multiprocessing.cpu_count())
 
-    parallel_pool = multiprocessing.Pool(num_parallel)
-    validation_results = parallel_pool.starmap(_validation_worker, \
-        zip([Path(pathname).resolve(strict=True) for pathname in args.path], repeat(args)))
+    with multiprocessing.Pool(num_parallel) as parallel_pool:
+        validation_results = parallel_pool.starmap(_validation_worker, \
+            zip([Path(pathname).resolve(strict=True) for pathname in args.path], repeat(args)))
 
     if not all(validation_results):
         sys.exit(1)

--- a/validate/validate_types.py
+++ b/validate/validate_types.py
@@ -3,5 +3,5 @@ from collections import namedtuple
 
 ValidateArgs = namedtuple(
     'args',
-    'path, cram_reference'
+    'path, cram_reference, cpus'
 )

--- a/validate/validate_types.py
+++ b/validate/validate_types.py
@@ -3,5 +3,5 @@ from collections import namedtuple
 
 ValidateArgs = namedtuple(
     'args',
-    'path, cram_reference, cpus'
+    'path, cram_reference, processes'
 )


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->

Adding option for parallelization of validation to speed up validation when performed on multiple files

---
## Test Results

Tested with default no parallelization and with parallelization across 2 CPUs, with the expected improvement in runtime:

```
+ docker run --rm -v /scratch/79575:/scratch/79575 -w /scratch/79575 -u `id -u`:`id -g` -c 3 validate:test validate test.g.vcf.gz test2.g.vcf.gz
Input: /scratch/79575/test.g.vcf.gz is valid file-vcf
Input: /scratch/79575/test2.g.vcf.gz is valid file-vcf

real    0m48.683s
user    0m0.016s
sys     0m0.021s
+ docker run --rm -v /scratch/79575:/scratch/79575 -w /scratch/79575 -u `id -u`:`id -g` -c 3 validate:test validate test.g.vcf.gz test2.g.vcf.gz -c 2
Input: /scratch/79575/test.g.vcf.gz is valid file-vcf
Input: /scratch/79575/test2.g.vcf.gz is valid file-vcf

real    0m24.695s
user    0m0.013s
sys     0m0.025s
```

---

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

### File Commits

- [X] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [X] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.

- [X] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

### Code Review Best Practices

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

### Testing

- [X] I have added unit tests for the new feature(s).

- [X] I modified the integration test(s) to include the new feature.

- [X] All new and previously existing tests passed locally and/or on the cluster.

- [X] The docker image built successfully on the cluster.
