### PR TITLE
Compression integrity checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [5.0.0-rc.3] - 2023-12-07
+### Added
+- Integrity test for compressed files
+
+---
+
 ## [5.0.0-rc.2] - 2023-12-06
 ### Added
 - FASTQ validator

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ options:
                         Path to reference file for CRAM
   -p PROCESSES, --processes PROCESSES
                         Number of processes to run in parallel when validating multiple files
+  -t, --test-integrity  Whether to perform a full integrity test on compressed files
 ```
 
 The tool will attempt to automatically detect the file type based on extension and perform the approriate validations. The tool will also perform an existence check along with a checksum check if an MD5 or SHA512 checksum exists regardless of file type.

--- a/pipeval/__init__.py
+++ b/pipeval/__init__.py
@@ -1,3 +1,3 @@
 '''Inits pipeval module'''
 
-__version__ = '5.0.0-rc.2'
+__version__ = '5.0.0-rc.3'

--- a/pipeval/validate/__main__.py
+++ b/pipeval/validate/__main__.py
@@ -28,5 +28,7 @@ def add_subparser_validate(subparsers:argparse._SubParsersAction):
         help='Path to reference file for CRAM')
     parser.add_argument('-p', '--processes', type=positive_integer, default=1, \
         help='Number of processes to run in parallel when validating multiple files')
+    parser.add_argument('-t', '--test-integrity', action='store_true', \
+        help='Whether to perform a full integrity test on compressed files')
 
     parser.set_defaults(func=run_validate)

--- a/pipeval/validate/files.py
+++ b/pipeval/validate/files.py
@@ -1,16 +1,52 @@
 ''' File checking functions '''
 from pathlib import Path
+from typing import Union
 import warnings
+import zlib
+import gzip
+import bz2
 import magic
 
-def _check_compressed(path:Path):
-    ''' Check file is compressed '''
-    compression_mimes = [
-        'application/x-gzip',
-        'application/x-bzip2'
-    ]
-    if magic.from_file(path.resolve(), mime=True) not in compression_mimes:
+def _identify_compression(path:Path):
+    ''' Identify compression type and returns appropriate file handler '''
+    compression_handlers = {
+        'application/x-gzip': gzip.open,
+        'application/x-bzip2': bz2.open
+    }
+
+    file_mime = magic.from_file(path.resolve(), mime=True)
+    return compression_handlers.get(file_mime, None)
+
+def _check_compression_integrity(path:Path, handler:Union[gzip.open,bz2.open]):
+    ''' Verify integrity of compressed file '''
+    integrity_error = ''
+    read_chunk_size = 1000000 # 1 MB chunks
+
+    with handler(path, 'rb') as file_reader:
+        try:
+            while file_reader.read(read_chunk_size) != b'':
+                pass
+        except gzip.BadGzipFile as bad_gzip:
+            integrity_error = f'Invalid Gzip file: {str(bad_gzip)}'
+        except EOFError as eof_error:
+            integrity_error = f'Truncated or corrupted file: {str(eof_error)}'
+        except zlib.error as zlib_error:
+            integrity_error = f'Decompression error: {str(zlib_error)}'
+
+    if integrity_error != '':
+        raise TypeError(f'Compression integrity check failed: {integrity_error}')
+
+def _check_compressed(path:Path, test_integrity:bool):
+    ''' Check file compression '''
+
+    file_handler = _identify_compression(path)
+
+    if file_handler is None:
         warnings.warn(f'Warning: file {path} is not compressed.')
+        return
+
+    if test_integrity:
+        _check_compression_integrity(path, file_handler)
 
 def _path_exists(path:Path):
     ''' Check if path exists '''

--- a/pipeval/validate/files.py
+++ b/pipeval/validate/files.py
@@ -27,11 +27,11 @@ def _check_compression_integrity(path:Path, handler:Union[gzip.open,bz2.open]):
             while file_reader.read(read_chunk_size) != b'':
                 pass
         except gzip.BadGzipFile as bad_gzip:
-            integrity_error = f'Invalid Gzip file: {str(bad_gzip)}'
+            integrity_error = f'Invalid Gzip file: {bad_gzip}'
         except EOFError as eof_error:
-            integrity_error = f'Truncated or corrupted file: {str(eof_error)}'
+            integrity_error = f'Truncated or corrupted file: {eof_error}'
         except zlib.error as zlib_error:
-            integrity_error = f'Decompression error: {str(zlib_error)}'
+            integrity_error = f'Decompression error: {zlib_error}'
 
     if integrity_error != '':
         raise TypeError(f'Compression integrity check failed: {integrity_error}')

--- a/pipeval/validate/validate.py
+++ b/pipeval/validate/validate.py
@@ -54,7 +54,7 @@ def _validate_file(
         raise TypeError(f'File {path} does not have a valid extension.')
 
     if file_type in CHECK_COMPRESSION_TYPES:
-        _check_compressed(path)
+        _check_compressed(path, args.test_integrity)
 
     _validate_checksums(path)
 

--- a/pipeval/validate/validate_types.py
+++ b/pipeval/validate/validate_types.py
@@ -3,5 +3,5 @@ from collections import namedtuple
 
 ValidateArgs = namedtuple(
     'args',
-    'path, cram_reference, processes'
+    'path, cram_reference, processes, test_integrity'
 )

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -125,7 +125,11 @@ def test__check_compressed__raises_warning_for_uncompressed_path(mock_path, mock
 @mock.patch('pipeval.validate.files._check_compression_integrity')
 @mock.patch('pipeval.validate.files.magic.from_file')
 @mock.patch('pipeval.validate.files.Path', autospec=True)
-def test__check_compressed__passes_compression_check(mock_path, mock_magic, mock_integrity, compression_mime):
+def test__check_compressed__passes_compression_check(
+    mock_path,
+    mock_magic,
+    mock_integrity,
+    compression_mime):
     mock_magic.return_value = compression_mime
     mock_integrity.return_value = None
     test_args = ValidateArgs(path=[], cram_reference=None, processes=1, test_integrity=False)


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->

Adding integrity check option for compressed files.

---
## Test Results
Tested with:
```Bash
#!/bin/bash
echo "empty BAM"
pipeval validate  test_files/empty_bam.bam

printf "\n"

echo "invalid BAM"
pipeval validate  test_files/invalid.bam

printf "\n"

echo "pass BAM"
pipeval validate  test_files/pass.bam

printf "\n"

echo "BAM with no index"
pipeval validate  test_files/noindex.bam

printf "\n"

echo "Just text file"
pipeval validate  test_files/hello.txt

printf "\n"

echo "Failing checksum MD5"
pipeval validate  test_files/hello_bad_md5.txt

echo "Failing checksum SHA512"
pipeval validate  test_files/hello_bad_sha512.txt

printf "\n"

echo "Generate md5 checksum"
pipeval generate-checksum -t md5 test_files/togen.txt

echo "Generate sha512 checksum"
pipeval generate-checksum -t sha512 test_files/togen.txt

echo "Validate generated checksums"
pipeval validate test_files/togen.txt

rm test_files/togen.txt.md5
rm test_files/togen.txt.sha512

printf "\n"

echo "Valid VCF"
pipeval validate  test_files/test_vcf.vcf.gz

printf "\n"

echo "Valid CRAM"
pipeval validate test_files/valid.cram -r /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta

printf "\n"

echo "CRAM with no index"
pipeval validate test_files/noindex.cram -r /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta

printf "\n"

echo "CRAM with default reference"
pipeval validate test_files/default_ref.cram

printf "\n"

echo "Invalid CRAM"
pipeval validate test_files/invalid.cram -r /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta

printf "\n"

echo "Valid SAM"
pipeval validate test_files/valid.sam

printf "\n"

echo "Valid FASTQ"
pipeval validate test.fq.gz -t

printf "\n"

echo "Truncated FASTQ"
pipeval validate test_13.fastq

printf "\n"

echo "Bad record FASTQ"
pipeval validate test_invalid.fastq.bz2 -t

```
---

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

### File Commits

- [X] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [X] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.

- [X] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

### Code Review Best Practices

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

### Testing

- [X] I have added unit tests for the new feature(s).

- [X] I modified the integration test(s) to include the new feature.

- [X] All new and previously existing tests passed locally and/or on the cluster.

- [X] The docker image built successfully on the cluster.
