### PR TITLE
Checksum flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
-## [Unreleased]
+## [5.0.0] - 2024-02-16
+### Added
+- Validation skip functionality for checksums
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ Input: path/to/input is valid <file-type>
 Error: path/to/input <error message>
 ```
 
+#### Validation Skipping
+
+Certain validations can be skipped through environment variables.
+|ENV VAR|Notes|
+|:---:|:---:|
+|PIPEVAL_SKIP_CHECKSUM|Flag to disable checksum validation. Set to `true` to disable checksum validation within PipeVal.|
+
 ### `pipeval generate-checksum`
 ```
 usage: pipeval generate-checksum [-h] [-t {md5,sha512}] [-v] path [path ...]

--- a/pipeval/common.py
+++ b/pipeval/common.py
@@ -1,6 +1,7 @@
 """ Common functions for PipeVal """
 import os
 
+# pylint: disable=C0103,W0613
 def skippedValidation(name):
     """
     Conditionally mark a validation to be skipped
@@ -12,9 +13,8 @@ def skippedValidation(name):
         return func
 
     def do_nothing(func):
-        skip_message = f'PID:{os.getpid()} - Skipping validation {name.upper()}'
         return lambda *args, **kwargs: \
-            print('PID:{} - Skipping validation {}'.format(os.getpid(), name.upper()))
+            print(f'PID:{os.getpid()} - Skipping validation {name.upper()}')
 
     value = os.environ.get(f"PIPEVAL_SKIP_{name.upper()}")
     should_skip_validate = value is not None and value.lower() == 'true'

--- a/pipeval/common.py
+++ b/pipeval/common.py
@@ -1,5 +1,6 @@
 """ Common functions for PipeVal """
 import os
+from functools import wraps
 
 # pylint: disable=C0103,W0613
 def skippedValidation(name):
@@ -12,9 +13,12 @@ def skippedValidation(name):
     def decorator(func):
         return func
 
-    def do_nothing(func):
-        return lambda *args, **kwargs: \
+    def print_skip_message(func):
+        @wraps(func)
+        def skip_message(*args, **kwargs):
             print(f'PID:{os.getpid()} - Skipping validation {name.upper()}')
+
+        return skip_message
 
     value = os.environ.get(f"PIPEVAL_SKIP_{name.upper()}")
     should_skip_validate = value is not None and value.lower() == 'true'
@@ -22,4 +26,4 @@ def skippedValidation(name):
     if not should_skip_validate:
         return decorator
 
-    return do_nothing
+    return print_skip_message

--- a/pipeval/common.py
+++ b/pipeval/common.py
@@ -1,0 +1,25 @@
+""" Common functions for PipeVal """
+import os
+
+def skippedValidation(name):
+    """
+    Conditionally mark a validation to be skipped
+
+    If the environment variable f'PIPEVAL_SKIP_{name}' is set to `true`,
+    the decorated function will skip that validation.
+    """
+    def decorator(func):
+        return func
+
+    def do_nothing(func):
+        skip_message = f'PID:{os.getpid()} - Skipping validation {name.upper()}'
+        return lambda *args, **kwargs: \
+            print('PID:{} - Skipping validation {}'.format(os.getpid(), name.upper()))
+
+    value = os.environ.get(f"PIPEVAL_SKIP_{name.upper()}")
+    should_skip_validate = value is not None and value.lower() == 'true'
+
+    if not should_skip_validate:
+        return decorator
+
+    return do_nothing

--- a/pipeval/generate_checksum/checksum.py
+++ b/pipeval/generate_checksum/checksum.py
@@ -5,11 +5,14 @@ from collections import namedtuple
 from typing import Dict, Union
 from pathlib import Path
 
+from pipeval.common import skippedValidation
+
 ChecksumArgs = namedtuple(
     'args',
     'path, type'
 )
 
+@skippedValidation('CHECKSUM')
 def _validate_checksums(path:Path):
     ''' Validate MD5 and/or SHA512 checksums '''
     # Checksum validation

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -1,0 +1,31 @@
+# pylint: disable=C0116
+# pylint: disable=C0114
+from pipeval.common import skippedValidation
+
+def test__skippedValidation__properly_skips_function_call(monkeypatch, capsys):
+    monkeypatch.setenv('PIPEVAL_SKIP_CHECKSUM', 'true')
+
+    @skippedValidation('CHECKSUM')
+    def to_be_decorated():
+        print('Decorated function called')
+
+    to_be_decorated()
+
+    out, _ = capsys.readouterr()
+
+    assert 'Skipping validation CHECKSUM' in out
+    assert 'Decorated function called' not in out
+
+def test__skippedValidation__properly_calls_function(monkeypatch, capsys):
+    monkeypatch.setenv('PIPEVAL_SKIP_CHECKSUM', 'false')
+
+    @skippedValidation('CHECKSUM')
+    def to_be_decorated():
+        print('Decorated function called')
+
+    to_be_decorated()
+
+    out, _ = capsys.readouterr()
+
+    assert 'Skipping validation CHECKSUM' not in out
+    assert 'Decorated function called' in out

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -1,5 +1,6 @@
 # pylint: disable=C0116
 # pylint: disable=C0114
+# pylint: disable=C0103
 from pipeval.common import skippedValidation
 
 def test__skippedValidation__properly_skips_function_call(monkeypatch, capsys):


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->

Adding functionality to skip checksum validation through environment variables. The checksum generation gets long in runtime for very large files so adding the option to skip checksum validation as needed.

---
## Test Results

<!--- Please test the following in a built docker image.  --->
Tested with pytest with added tests

---

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

### File Commits

- [X] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [X] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.

- [X] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

### Code Review Best Practices

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

### Testing

- [X] I have added unit tests for the new feature(s).

- [ ] I modified the integration test(s) to include the new feature.

- [X] All new and previously existing tests passed locally and/or on the cluster.

- [X] The docker image built successfully on the cluster.
