### PR TITLE
add support for unmmapped bams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Added
 - Add validation flowchart
-
+- Add support for unmapped BAM
 ---
 
 ## [5.0.0] - 2024-02-16
@@ -72,7 +72,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-### Removed 
+### Removed
 - Remove deprecated parameter options from README
 - Remove inaccessible design doc link from README
 - Remove directory checking

--- a/pipeval/validate/__main__.py
+++ b/pipeval/validate/__main__.py
@@ -16,7 +16,7 @@ def positive_integer(arg):
 
 def add_subparser_validate(subparsers:argparse._SubParsersAction):
     """ Parse arguments """
-    parser = subparsers.add_parser(
+    parser:argparse.ArgumentParser = subparsers.add_parser(
         name = 'validate',
         help = 'Validate one or more file(s)',
         description = 'Validate one or more file(s)',
@@ -26,6 +26,8 @@ def add_subparser_validate(subparsers:argparse._SubParsersAction):
     parser.add_argument('path', help='One or more paths of files to validate', type=str, nargs='+')
     parser.add_argument('-r', '--cram-reference', default=None, \
         help='Path to reference file for CRAM')
+    parser.add_argument('-u', '--unmapped-bam', action='store_true',
+        help='Input is unmmapped BAM.')
     parser.add_argument('-p', '--processes', type=positive_integer, default=1, \
         help='Number of processes to run in parallel when validating multiple files')
     parser.add_argument('-t', '--test-integrity', action='store_true', \

--- a/pipeval/validate/validate.py
+++ b/pipeval/validate/validate.py
@@ -47,6 +47,7 @@ def _validate_file(
         `args` must contain the following:
         `path` is a required argument with a value of list of files
         `cram_reference` is a required argument with either a string value or None
+        `unmapped_bam` is a required argument of boolean variable
     '''
     _path_exists(path)
 

--- a/pipeval/validate/validate_types.py
+++ b/pipeval/validate/validate_types.py
@@ -3,5 +3,5 @@ from collections import namedtuple
 
 ValidateArgs = namedtuple(
     'args',
-    'path, cram_reference, processes, test_integrity'
+    'path, cram_reference, unmapped_bam, processes, test_integrity'
 )

--- a/pipeval/validate/validators/bam.py
+++ b/pipeval/validate/validators/bam.py
@@ -6,10 +6,13 @@ import pysam
 
 from pipeval.validate.validate_types import ValidateArgs
 
-def _validate_bam_file(path:Path):
+def _validate_bam_file(path:Path, unmapped_bam:bool):
     '''Validates bam file'''
+    args = [str(path)]
+    if unmapped_bam:
+        args.append('-u')
     try:
-        pysam.quickcheck(str(path))
+        pysam.quickcheck(*args)
     except pysam.SamtoolsError as err:
         raise ValueError("samtools bam check failed. " + str(err)) from err
 
@@ -35,5 +38,5 @@ def _check_bam(path:Path, args:Union[ValidateArgs,Dict[str, Union[str,list]]]):
     `args` must contains the following:
         `cram_reference` is a required key with either a string value or None
     '''
-    _validate_bam_file(path)
+    _validate_bam_file(path, args.unmapped_bam)
     _check_bam_index(path)

--- a/pipeval/validate/validators/bam.py
+++ b/pipeval/validate/validators/bam.py
@@ -16,7 +16,12 @@ def _validate_bam_file(path:Path, unmapped_bam:bool):
     except pysam.SamtoolsError as err:
         raise ValueError("samtools bam check failed. " + str(err)) from err
 
-    bam_head: pysam.IteratorRowHead = pysam.AlignmentFile(str(path)).head(1)
+    kwargs = {
+        'filename': str(path)
+    }
+    if unmapped_bam:
+        kwargs['check_sq'] = False
+    bam_head: pysam.IteratorRowHead = pysam.AlignmentFile(**kwargs).head(1)
     if next(bam_head, None) is None:
         raise ValueError("pysam bam check failed. No reads in " + str(path))
 

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -110,7 +110,13 @@ def test__path_exists__errors_for_non_existing_path(mock_path):
 @mock.patch('pipeval.validate.files.Path', autospec=True)
 def test__check_compressed__raises_warning_for_uncompressed_path(mock_path, mock_magic):
     mock_magic.return_value = 'text/plain'
-    test_args = ValidateArgs(path=[], cram_reference=None, processes=1, test_integrity=False)
+    test_args = ValidateArgs(
+        path=[],
+        cram_reference=None,
+        unmapped_bam=False,
+        processes=1,
+        test_integrity=False
+    )
 
     with pytest.warns(UserWarning):
         _check_compressed(mock_path, test_args)
@@ -132,7 +138,13 @@ def test__check_compressed__passes_compression_check(
     compression_mime):
     mock_magic.return_value = compression_mime
     mock_integrity.return_value = None
-    test_args = ValidateArgs(path=[], cram_reference=None, processes=1, test_integrity=False)
+    test_args = ValidateArgs(
+        path=[],
+        cram_reference=None,
+        unmapped_bam=False,
+        processes=1,
+        test_integrity=False
+    )
 
     with warnings.catch_warnings():
         warnings.filterwarnings("error")
@@ -147,14 +159,14 @@ def test__validate_bam_file__empty_bam_file(mock_pysam):
     test_path = Path('empty/valid/bam')
 
     with pytest.raises(ValueError):
-        _validate_bam_file(test_path)
+        _validate_bam_file(test_path, unmapped_bam=False)
 
 @mock.patch('pipeval.validate.validators.bam.Path', autospec=True)
 def test__validate_bam_file__quickcheck_fails(mock_path):
     mock_path.exists.return_value = False
 
     with pytest.raises(ValueError):
-        _validate_bam_file(mock_path)
+        _validate_bam_file(mock_path, unmapped_bam=False)
 
 @mock.patch('pipeval.validate.validators.bam.pysam', autospec=True)
 def test__check_bam_index__no_index_file_error(mock_pysam):
@@ -247,7 +259,13 @@ def test__validate_vcf_file__passes_vcf_validation(mock_call):
     _validate_vcf_file('some/file')
 
 def test__run_validate__passes_validation_no_files():
-    test_args = ValidateArgs(path=[], cram_reference=None, processes=1, test_integrity=False)
+    test_args = ValidateArgs(
+        path=[],
+        cram_reference=None,
+        unmapped_bam=False,
+        processes=1,
+        test_integrity=False
+    )
     run_validate(test_args)
 
 @pytest.mark.parametrize(
@@ -273,6 +291,7 @@ def test___validation_worker__fails_with_failing_checks(
     test_args = ValidateArgs(
         path=[test_path],
         cram_reference=None,
+        unmapped_bam=False,
         processes=1,
         test_integrity=False)
     mock_path_resolve.return_value = test_path
@@ -292,6 +311,7 @@ def test__run_validate__passes_on_all_valid_files(
     test_args = ValidateArgs(
         path=[test_path],
         cram_reference=None,
+        unmapped_bam=False,
         processes=1,
         test_integrity=False)
 
@@ -309,6 +329,7 @@ def test__run_validate__fails_with_failing_file(
     test_args = ValidateArgs(
         path=[test_path],
         cram_reference=None,
+        unmapped_bam=False,
         processes=1,
         test_integrity=False)
     expected_code = 1
@@ -352,6 +373,7 @@ def test__validate_file__checks_compression(
     test_args = ValidateArgs(
         path=[],
         cram_reference=None,
+        unmapped_bam=False,
         processes=1,
         test_integrity=False)
 
@@ -369,6 +391,7 @@ def test__run_validate__fails_on_unresolvable_symlink(mock_path_resolve):
     test_args = ValidateArgs(
         path=[test_path],
         cram_reference=None,
+        unmapped_bam=False,
         processes=1,
         test_integrity=False)
 
@@ -394,6 +417,7 @@ def test___validation_worker__passes_proper_validation(
     test_args = ValidateArgs(
         path=[test_path],
         cram_reference=None,
+        unmapped_bam=False,
         processes=1,
         test_integrity=False)
 


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->

Command line argument `-u/--unmapped-bam` was added to avoid the error of `pysam.quickcheck` for unmapped bam files because of missing reference files in the BAM header.

I'm not very familiar with the unittest set up in this repo, so not sure how to add a test case. If anyone could help me with this it would be fantastic.

### Closes #97   <!-- edit if this PR closes an Issue -->

---
## Test Results

<!--- Please test the following in a built docker image.  --->


### Validation Test

#### BAM

Case 1 - test type: <!-- e.g. fail on invalid, fail on empty, pass on valid, etc.  -->
- input file(s):
   ```
   path/to/input
   ```
- command: 
  ```
  <command used>
  ```
- output: 
  ```
  path/to/output OR output-message
  ```

#### VCF
Case 1 - test: <!-- e.g. fail on invalid, fail on empty, pass on valid, etc.  -->
- input file(s):
   ```
   path/to/input
   ```
- command: 
  ```
  <command used>
  ```
- output: 
  ```
  path/to/output OR output-message
  ```

Case 2 - test: <!-- e.g. pass on valid, fail on invalid, fail on empty, etc.  -->
- input file(s):
   ```
   path/to/input
   ```
- command: 
  ```
  <command used>
  ```
- output: 
  ```
  path/to/output OR output-message
  ```
--- 
### Checksum Test

Case 1 - test: <!-- e.g. pass on valid checksum, fail on invalid checksum, checksum generation, etc.  -->
- input file(s):
   ```
   path/to/input
   ```
- command: 
  ```
  <command used>
  ```
- output: 
  ```
  path/to/output OR output-message
  ```

---

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

### File Commits

- [X] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [X] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.

- [X] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

### Code Review Best Practices

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

### Testing

- [ ] I have added unit tests for the new feature(s).

- [X] I modified the integration test(s) to include the new feature.

- [ ] All new and previously existing tests passed locally and/or on the cluster.

- [ ] The docker image built successfully on the cluster.
